### PR TITLE
Improve variant inventory handling

### DIFF
--- a/functions/test/applyVariantSettings.test.js
+++ b/functions/test/applyVariantSettings.test.js
@@ -1,0 +1,51 @@
+const assert = require("assert");
+const { applyVariantInventorySettings } = require("../batchOptimizer-v3");
+
+// Quantity range test
+(() => {
+  const variant = { price: "10" };
+  const settings = {
+    qty_min: 2,
+    qty_max: 5,
+    variant_inventory_policy: "allow",
+    track_quantity: true
+  };
+  applyVariantInventorySettings(variant, settings);
+  assert(variant.inventory_quantity >= 2 && variant.inventory_quantity <= 5);
+  assert.strictEqual(variant.inventory_policy, "allow");
+  assert.strictEqual(variant.inventory_management, "shopify");
+})();
+
+// Price adjust and rounding test
+(() => {
+  const variant = { price: "10.00" };
+  const settings = {
+    qty_min: 0,
+    qty_max: 0,
+    adjustPrices: true,
+    adjustmentAmount: 5,
+    roundPrices: true,
+    roundingNumber: 0.5,
+    currency: "USD"
+  };
+  applyVariantInventorySettings(variant, settings);
+  assert.strictEqual(variant.price, "15.50");
+  assert.strictEqual(variant.price_currency, "USD");
+})();
+
+// Compare-at price strategies
+(() => {
+  const variant = { price: "10.00" };
+  const settings = {
+    qty_min: 0,
+    qty_max: 0,
+    compare_at_strategy: "+",
+    compare_at_amount: 5,
+    currency: "EUR"
+  };
+  applyVariantInventorySettings(variant, settings);
+  assert.strictEqual(variant.compare_at_price, "15.00");
+  assert.strictEqual(variant.compare_at_price_currency, "EUR");
+})();
+
+console.log("All tests passed.");


### PR DESCRIPTION
## Summary
- add `applyVariantInventorySettings` helper to manage variant options
- update inventory loop in `batchOptimizer-v3.js` to apply inventory and price logic
- cover new helper in tests

## Testing
- `npm run lint`
- `node test/applyVariantSettings.test.js`


------
https://chatgpt.com/codex/tasks/task_e_684487a9ab98832286b5b60ffc84c78f