### PR TITLE
Sort by relevance first in Dataforseo

### DIFF
--- a/functions/batchOptimizer-v3.js
+++ b/functions/batchOptimizer-v3.js
@@ -170,7 +170,10 @@ async function fetchDataforseoKeywords(seeds, settings, auth) {
       limit: Number(settings.limit) || 10,
       closely_variants: settings.closely_variants,
       ignore_synonyms: settings.ignore_synonyms,
-      order_by: `${settings.sort_field},${settings.sort_order}`,
+      order_by: [
+        "relevance,desc",
+        `${settings.sort_field},${settings.sort_order}`,
+      ],
       filters: (settings.filters || []).map((f) => [
         `keyword_data.${f.field}`,
         f.operator,


### PR DESCRIPTION
## Summary
- change keyword order settings to add `relevance,desc` before the configured sort field

## Testing
- `node functions/test/applyVariantSettings.test.js`
- `npm --prefix functions run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c4b3373ac8322b17debbc8fc24f10